### PR TITLE
Fixed a bug when checking package version with non-standard character

### DIFF
--- a/src/sweights/sweight.py
+++ b/src/sweights/sweight.py
@@ -476,7 +476,7 @@ class SWeight:
     def _run_tsplot(self):
         assert self.method == "tsplot"
 
-        R = import_optional_module("ROOT", min_version=6)
+        R = import_optional_module("ROOT", min_version="6")
 
         # this works very differently for nD fits
         # so will not implement it here

--- a/src/sweights/util.py
+++ b/src/sweights/util.py
@@ -51,6 +51,7 @@ def import_optional_module(name: str, *, min_version: str = "") -> Any:
 
         if min_version:
             version = getattr(mod, "__version__", "0")
+            version = ''.join(filter(lambda x: x.isdigit() or x == '.', version))
 
             if not Version(min_version) <= Version(version):
                 msg = (

--- a/src/sweights/util.py
+++ b/src/sweights/util.py
@@ -51,7 +51,7 @@ def import_optional_module(name: str, *, min_version: str = "") -> Any:
 
         if min_version:
             version = getattr(mod, "__version__", "0")
-            version = ''.join(filter(lambda x: x.isdigit() or x == '.', version))
+            version = "".join(filter(lambda x: x.isdigit() or x == ".", version))
 
             if not Version(min_version) <= Version(version):
                 msg = (

--- a/src/sweights/util.py
+++ b/src/sweights/util.py
@@ -51,13 +51,11 @@ def import_optional_module(name: str, *, min_version: str = "") -> Any:
 
         if min_version:
             version = getattr(mod, "__version__", "0")
-            version = "".join(filter(lambda x: x.isdigit() or x == ".", version))
+            version = _normalize_version(version)
+            min_version = _normalize_version(min_version)
 
             if not Version(min_version) <= Version(version):
-                msg = (
-                    f"{name} found, but does not match the "
-                    f"required minimum version{min_version}"
-                )
+                msg = f"{name} found, but does not match minimum version {min_version}"
                 raise ImportError(msg)
 
         return mod
@@ -68,6 +66,11 @@ def import_optional_module(name: str, *, min_version: str = "") -> Any:
             "please install it manually to use this function."
         )
         raise
+
+
+def _normalize_version(version: str) -> str:
+    """Replace / with . in non-standard ROOT version string."""
+    return version.replace("/", ".")
 
 
 def convert_rf_pdf(

--- a/tests/dummy_module.py
+++ b/tests/dummy_module.py
@@ -1,0 +1,3 @@
+"""Dummy module to test import_optional_module with a non-standard version string."""
+
+__version__ = "6.30/04"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,6 +6,23 @@ from scipy.integrate import quad
 from scipy.stats import norm, expon
 from typing import Annotated
 from iminuit.typing import Interval
+import sys
+from pathlib import Path
+
+
+def test_import_optional_module():
+    sys.path.append(Path(__file__).parent)
+    m = util.import_optional_module("dummy_module", min_version="6")
+    assert m.__version__ == "6.30/04"
+    with pytest.raises(ImportError):
+        util.import_optional_module("dummy_module", min_version="6.31")
+    with pytest.raises(ImportError):
+        util.import_optional_module("dummy_module", min_version="7")
+    with pytest.raises(
+        ImportError,
+        match=r"dummy_module found, but does not match minimum version 6\.30\.05",
+    ):
+        util.import_optional_module("dummy_module", min_version="6.30/05")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When converting a RooFit pdf to a python wrapper using convert_rf_pdf a check is performed on the ROOT version. 
If the ROOT version contains a non-standard character, eg. `/`, then the check will produce an error. For example using ROOT version 6.30/04 reproduces this issue.

This fix converts the version string so that is is parsed correctly.